### PR TITLE
Audio Upload to S3 in Correct MP3 Format

### DIFF
--- a/app/controllers/api/v1/user_responses_controller.rb
+++ b/app/controllers/api/v1/user_responses_controller.rb
@@ -9,11 +9,11 @@ class Api::V1::UserResponsesController < ApplicationController
       @new_user_response = UserResponse.create!(user_response_params)
       if @new_user_response.errors.full_messages.empty?
         # Proceed with transcribe job
-        create_transcribe_job_name = "launch-academy-interview-user-response-user-U#{@new_user_response.user_id}M#{@new_user_response.mock_interview_id}-Q#{@new_user_response.question_id}-UR#{@new_user_response.id}"
-        # job_response = aws_start_transcribe_job(create_transcribe_job_name, @new_user_response.audio.mp3.url)
+        create_transcribe_job_name = "launch-academy-interview-user-response-user-U#{@new_user_response.user_id}MI#{@new_user_response.mock_interview_id}-QU#{@new_user_response.question_id}-USR#{@new_user_response.id}"
+        job_response = aws_start_transcribe_job(create_transcribe_job_name, @new_user_response.audio.url)
 
-        # @new_user_response.update(aws_transcribe_job_name: job_response.transcription_job.transcription_job_name)
-        @new_user_response.update(aws_transcribe_job_name: 'launch-academy-interview-user-response-user-U1M13-Q43-UR12')
+        @new_user_response.update(aws_transcribe_job_name: job_response.transcription_job.transcription_job_name)
+        # @new_user_response.update(aws_transcribe_job_name: 'launch-academy-interview-user-response-user-U1M13-Q43-UR12')
 
 
         render json: { :user_response => @new_user_response }
@@ -26,7 +26,6 @@ class Api::V1::UserResponsesController < ApplicationController
   private
 
   def user_response_params
-    # params.permit(:audio_size, :audio_type, :audio_start_time, :audio_stop_time, :audio, :user_id, :mock_interview_id, :question_id, :aws_transcribe_job_name)
     params.permit(:audio_size, :audio_type, :audio_start_time, :audio_stop_time, :audio, :user_id, :mock_interview_id, :question_id)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery unless: -> { request.format.json? }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   validates :github_id, presence: true, exclusion: { in: [nil] }
   validates :github_login, presence: true, exclusion: { in: [nil] }, uniqueness: { case_sensitive: false }
-  validates_format_of :github_avatar_url, with: URI::regexp(["http", "https"])
+  validates_format_of :github_avatar_url, presence: true, exclusion: { in: [nil] }, with: URI::regexp(["http", "https"])
 
   has_many :user_responses
   has_many :mock_interviews

--- a/app/uploaders/user_response_uploader.rb
+++ b/app/uploaders/user_response_uploader.rb
@@ -1,36 +1,54 @@
 require 'fog/aws'
-
+#
 class UserResponseUploader < CarrierWave::Uploader::Base
-  # include CarrierWave::FFmpeg
   if Rails.env.test?
     storage :file
   else
     storage :fog
   end
 
-  version :mp3 do
-    process :generate_mp3
-
-    def full_filename(for_file)
-      super.chomp(File.extname(super)) + '.mp3'
-    end
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  # AWS::S3::S3Object
-  def download_url(filename)
-    url(response_content_disposition: %Q{attachment; filename="#{filename}"})
+  def full_filename(for_file)
+    super.chomp(File.extname(super)) + '.mp3'
   end
+
+  # process :generate_mp3
+  #
+
+  # storage :file
+
+  process :generate_mp3
+  process :set_mp3_content_type
+
+  # UPLOAD_EXTENSION = ".webm"
+  # def generate_mp3
+  #   temp_path = current_path.gsub(UPLOAD_EXTENSION, ".copy#{UPLOAD_EXTENSION}")
+  #   self.file.copy!(temp_path)
+  #   self.file.move_to(current_path.gsub(UPLOAD_EXTENSION, ".mp3"))
+  #   binding.pry
+  #   File.unlink(current_path)
+  #   # ffmpeg -i inputfile.wav -acodec libmp3lame -f mp3 watermarked.mp3
+  #   `ffmpeg -i "#{temp_path}" -sn -y -acodec libmp3lame -aq 4 -f mp3 "#{current_path}"`
+  #   self.file.content_type = ::MIME::Types.type_for(current_path).first.to_s
+  # end
 
   def generate_mp3
     temp_path = current_path.gsub(".weba", ".mp3")
     # ffmpeg -i inputfile.wav -acodec libmp3lame -f mp3 watermarked.mp3
-    puts "ffmpeg -i \"#{current_path}\" \"#{temp_path}\""
-    `ffmpeg -i "#{current_path}" "#{temp_path}"`
+    puts current_path
+    puts temp_path
+    # `ffmpeg -i "#{current_path}" -sn -y -acodec libmp3lame -aq 4 -f mp3 "#{temp_path}"`
+    `ffmpeg -i "#{current_path}" -sn -y -c:a libmp3lame -aq 4 -f mp3 "#{temp_path}"`
     File.unlink(current_path)
+    # FileUtils.cp(temp_path,"uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}")
     FileUtils.mv(temp_path, current_path)
+    # binding.pry
   end
 
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  def set_mp3_content_type
+    file.content_type = 'audio/mp3'
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
     <%= stylesheet_pack_tag "ptpApp/index" %>
   </head>
   <body>
+    <p class="notice"><%= notice %></p>
+    <p class="alert"><%= alert %></p>
     <%= yield %>
   </body>
 </html>

--- a/db/migrate/20180512123045_create_users.rb
+++ b/db/migrate/20180512123045_create_users.rb
@@ -1,9 +1,10 @@
 class CreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
-      t.integer :github_id
-      t.string :github_login
-      t.string :github_avatar_url
+      t.string :provider, null: false, default: 'github'
+      t.integer :github_id, null: false
+      t.string :github_login, null: false
+      t.string :github_avatar_url, null: false
       t.string :github_name
       t.integer :sign_in_count, default: 0
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,9 +72,10 @@ ActiveRecord::Schema.define(version: 2018_05_12_123141) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.integer "github_id"
-    t.string "github_login"
-    t.string "github_avatar_url"
+    t.string "provider", default: "github", null: false
+    t.integer "github_id", null: false
+    t.string "github_login", null: false
+    t.string "github_avatar_url", null: false
     t.string "github_name"
     t.integer "sign_in_count", default: 0
     t.datetime "created_at", null: false


### PR DESCRIPTION
For some time ran into issues getting CarrierWave to upload the newly-converted MP3 audio file to S3. 
 CarrierWave saved the MP3 version to file storage, but fog selection would upload the WEBM verison. 
 Working with [Dan Pickett](https://github.com/dpickett), able to resolve long-running issue by explicitly setting the content type to 'audio/mp3' before uploading converted file to S3.